### PR TITLE
Swap only optimal amount even when active ID moves

### DIFF
--- a/contracts/strategies/traderjoe/TraderJoe.sol
+++ b/contracts/strategies/traderjoe/TraderJoe.sol
@@ -178,7 +178,7 @@ contract TraderJoe is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
         uint256 pairDepositTokenIncrement = pairDepositTokenAfter -
             pairdepositTokenBefore;
 
-        TraderJoeInvestmentLib.swapTokens(
+        TraderJoeInvestmentLib.swapExactTokensForTokens(
             pairDepositTokenIncrement,
             strategyStorage.pairDepositToken,
             depositToken

--- a/contracts/strategies/traderjoe/TraderJoe.sol
+++ b/contracts/strategies/traderjoe/TraderJoe.sol
@@ -23,11 +23,11 @@ contract TraderJoe is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
 
     // solhint-disable-next-line const-name-snakecase
     string public constant trackingName =
-        "brokkr.traderjoe_strategy.traderjoe_strategy_v1.2.1";
+        "brokkr.traderjoe_strategy.traderjoe_strategy_v1.2.2";
     // solhint-disable-next-line const-name-snakecase
     string public constant humanReadableName = "TraderJoe Strategy";
     // solhint-disable-next-line const-name-snakecase
-    string public constant version = "1.2.1";
+    string public constant version = "1.2.2";
 
     struct TraderJoeArgs {
         ITraderJoeLBPair lbPair;


### PR DESCRIPTION
Handling edge case that active ID moves during swap on preparing params. The goal of this algorithm is to find the optimal amount `S`.

- Calculate all the necessary parameters including how much of which token to swap. (Let's call the amount to swap here as `S1`)
- If the swap will move active ID, then swap only amount, `S2`,  as much as need to move active ID. And restart this process with the new active ID. (Note that we must swap at least `S2`, otherwise we can't provide liquidity.)
- If no swap is required or the swap doesn't move active ID, we have all the right parameters including the optimal amounts of X and Y. It's done.

This leads us to optimal swap because `S` is the summation of `S2`s, which is equal to or smaller than `S1`.