### PR TITLE
fixing DCA truncation bug

### DIFF
--- a/contracts/beyondFramework/dca/base/DCABaseUpgradeableCutted.sol
+++ b/contracts/beyondFramework/dca/base/DCABaseUpgradeableCutted.sol
@@ -232,7 +232,12 @@ abstract contract DCABaseUpgradeableCutted is
             ) {
                 // not started position with the same amount split exists
                 // just add invested amount here
-                depositor.positions[i].depositAmount += amount;
+
+                // (amount / amountSplit) * amountSplit exression will produce the same truncation loss as the one
+                // that happens during adding the funds to the investment queue
+                depositor.positions[i].depositAmount +=
+                    (amount / amountSplit) *
+                    amountSplit;
 
                 emit Deposit(sender, amount, amountSplit);
                 return;

--- a/test/index/arbitrum/IndexArbitrum.test.ts
+++ b/test/index/arbitrum/IndexArbitrum.test.ts
@@ -4,12 +4,12 @@ import { ethers } from "hardhat"
 import { Arbitrum } from "../../../constants/networks/Arbitrum"
 import { deployStrategy } from "../../../scripts/contracts/forking/deploy"
 import { IndexTestOptions } from "../../helper/interfaces/options"
-import { testStrategy } from "../Strategy.test"
 import { burn, mint } from "../helper/InvestHelper"
+import { testStrategy } from "../Strategy.test"
 
 const indexAvalancheTestOptions: IndexTestOptions = {
   network: Arbitrum(),
-  forkAt: 91875300,
+  forkAt: 92206952,
 }
 
 testStrategy("IndexArbitrumDeFi Strategy - Deploy", deployIndexArbitrumDeFiStrategy, indexAvalancheTestOptions, [


### PR DESCRIPTION
How to trigger the bug
1. userA invest 1 USDC twice
2. userB withdraws everything

previous version of the code failed, as the investment queue values were truncated
while the user positions were not truncated